### PR TITLE
feat(vconfig)!: encrypt/decrypt use AES-256-GCM via VersionedEncryptor

### DIFF
--- a/src/Voyager.Configuration.Tool/Program.cs
+++ b/src/Voyager.Configuration.Tool/Program.cs
@@ -20,25 +20,36 @@ var jsonDocOptions = new JsonDocumentOptions
 // Shared options
 var keyOption = new Option<string?>(
     aliases: new[] { "--key", "-k" },
-    description: "Encryption key (not recommended - use --key-env instead)");
+    description: "AES-256 encryption key, Base64-encoded 32 bytes (not recommended - use --key-env instead)");
 
 var keyEnvOption = new Option<string>(
     aliases: new[] { "--key-env" },
     getDefaultValue: () => "ASPNETCORE_ENCODEKEY",
-    description: "Environment variable containing encryption key");
+    description: "Environment variable containing AES-256 encryption key");
 
-// encrypt-value command (backward compatibility)
+// Legacy DES support — only used by decrypt commands so older ciphertext can still be read.
+// Named distinctly from reencrypt's own legacyKeyEnvOption (which has different defaults).
+var decLegacyKeyOption = new Option<string?>(
+    aliases: new[] { "--legacy-key" },
+    description: "Legacy DES key (for reading pre-v2 ciphertext; not recommended - use --legacy-key-env)");
+
+var decLegacyKeyEnvOption = new Option<string?>(
+    aliases: new[] { "--legacy-key-env" },
+    description: "Environment variable containing legacy DES key (enables decrypting pre-v2 values)");
+
+// encrypt-value command — single value, AES-256-GCM
 var encryptValueCommand = new Command("encrypt-value", "Encrypt single text value");
 var encryptTextArg = new Argument<string>("text", "Text to encrypt");
 encryptValueCommand.AddArgument(encryptTextArg);
 encryptValueCommand.AddOption(keyOption);
 encryptValueCommand.AddOption(keyEnvOption);
-encryptValueCommand.SetHandler(async (string text, string? key, string keyEnv) =>
+encryptValueCommand.SetHandler((string text, string? key, string keyEnv) =>
 {
     try
     {
         var encryptionKey = GetEncryptionKey(key, keyEnv);
-        var encryptor = new Encryptor(encryptionKey);
+        using var aesCipher = new AesGcmCipherProvider(encryptionKey);
+        var encryptor = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
         var encrypted = encryptor.Encrypt(text);
         Console.WriteLine(encrypted);
     }
@@ -52,18 +63,22 @@ encryptTextArg,
 keyOption,
 keyEnvOption);
 
-// decrypt-value command (backward compatibility)
+// decrypt-value command — AES-256-GCM with optional legacy DES fallback
 var decryptValueCommand = new Command("decrypt-value", "Decrypt single text value");
 var decryptTextArg = new Argument<string>("encrypted", "Encrypted text to decrypt");
 decryptValueCommand.AddArgument(decryptTextArg);
 decryptValueCommand.AddOption(keyOption);
 decryptValueCommand.AddOption(keyEnvOption);
-decryptValueCommand.SetHandler(async (string encrypted, string? key, string keyEnv) =>
+decryptValueCommand.AddOption(decLegacyKeyOption);
+decryptValueCommand.AddOption(decLegacyKeyEnvOption);
+decryptValueCommand.SetHandler((string encrypted, string? key, string keyEnv, string? legacyKey, string? legacyKeyEnv) =>
 {
     try
     {
         var encryptionKey = GetEncryptionKey(key, keyEnv);
-        var encryptor = new Encryptor(encryptionKey);
+        using var aesCipher = new AesGcmCipherProvider(encryptionKey);
+        var legacyDes = GetOptionalLegacyDes(legacyKey, legacyKeyEnv);
+        var encryptor = new VersionedEncryptor(aesCipher, legacyDes, allowLegacyDes: legacyDes != null);
         var decrypted = encryptor.Decrypt(encrypted);
         Console.WriteLine(decrypted);
     }
@@ -75,7 +90,9 @@ decryptValueCommand.SetHandler(async (string encrypted, string? key, string keyE
 },
 decryptTextArg,
 keyOption,
-keyEnvOption);
+keyEnvOption,
+decLegacyKeyOption,
+decLegacyKeyEnvOption);
 
 // encrypt command (JSON file)
 var encryptCommand = new Command("encrypt", "Encrypt values in JSON configuration file");
@@ -110,7 +127,8 @@ encryptCommand.SetHandler(async (FileInfo input, FileInfo? output, string? key, 
         }
 
         var encryptionKey = GetEncryptionKey(key, keyEnv);
-        var encryptor = new Encryptor(encryptionKey);
+        using var aesCipher = new AesGcmCipherProvider(encryptionKey);
+        var encryptor = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
 
         // Determine output file
         var outputFile = inPlace ? input : (output ?? input);
@@ -171,9 +189,19 @@ decryptCommand.AddOption(decryptOutputOption);
 decryptCommand.AddOption(keyOption);
 decryptCommand.AddOption(keyEnvOption);
 decryptCommand.AddOption(forceOption);
+decryptCommand.AddOption(decLegacyKeyOption);
+decryptCommand.AddOption(decLegacyKeyEnvOption);
 
-decryptCommand.SetHandler(async (FileInfo input, FileInfo output, string? key, string keyEnv, bool force) =>
+decryptCommand.SetHandler(async (System.CommandLine.Invocation.InvocationContext ctx) =>
 {
+    var input = ctx.ParseResult.GetValueForOption(decryptInputOption)!;
+    var output = ctx.ParseResult.GetValueForOption(decryptOutputOption)!;
+    var key = ctx.ParseResult.GetValueForOption(keyOption);
+    var keyEnv = ctx.ParseResult.GetValueForOption(keyEnvOption)!;
+    var force = ctx.ParseResult.GetValueForOption(forceOption);
+    var legacyKey = ctx.ParseResult.GetValueForOption(decLegacyKeyOption);
+    var legacyKeyEnv = ctx.ParseResult.GetValueForOption(decLegacyKeyEnvOption);
+
     try
     {
         if (!input.Exists)
@@ -183,7 +211,9 @@ decryptCommand.SetHandler(async (FileInfo input, FileInfo output, string? key, s
         }
 
         var encryptionKey = GetEncryptionKey(key, keyEnv);
-        var encryptor = new Encryptor(encryptionKey);
+        using var aesCipher = new AesGcmCipherProvider(encryptionKey);
+        var legacyDes = GetOptionalLegacyDes(legacyKey, legacyKeyEnv);
+        var encryptor = new VersionedEncryptor(aesCipher, legacyDes, allowLegacyDes: legacyDes != null);
 
         if (output.Exists && !force)
         {
@@ -219,12 +249,7 @@ decryptCommand.SetHandler(async (FileInfo input, FileInfo output, string? key, s
         Console.Error.WriteLine($"Error: {ex.Message}");
         Environment.Exit(1);
     }
-},
-decryptInputOption,
-decryptOutputOption,
-keyOption,
-keyEnvOption,
-forceOption);
+});
 
 // keygen command — generate AES-256 key
 var keygenCommand = new Command("keygen", "Generate a new AES-256 encryption key");
@@ -357,6 +382,28 @@ static string GetEncryptionKey(string? keyParam, string keyEnvVar)
     }
 
     return key;
+}
+
+// Resolves the legacy DES key from either --legacy-key (warned) or --legacy-key-env.
+// Returns null when neither is supplied — caller decides whether legacy support is needed.
+static IEncryptor? GetOptionalLegacyDes(string? legacyKey, string? legacyKeyEnv)
+{
+    string? resolved = null;
+    if (!string.IsNullOrWhiteSpace(legacyKey))
+    {
+        Console.WriteLine("⚠️  Warning: Passing legacy key via --legacy-key is not secure. Use --legacy-key-env instead.");
+        resolved = legacyKey;
+    }
+    else if (!string.IsNullOrWhiteSpace(legacyKeyEnv))
+    {
+        resolved = Environment.GetEnvironmentVariable(legacyKeyEnv);
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            throw new Exception($"Legacy DES key not found in environment variable '{legacyKeyEnv}'.");
+        }
+    }
+
+    return resolved != null ? new Encryptor(resolved) : null;
 }
 
 static JsonNode EncryptJsonNode(JsonNode node, IEncryptor encryptor)

--- a/src/Voyager.Configuration.Tool/Program.cs
+++ b/src/Voyager.Configuration.Tool/Program.cs
@@ -25,7 +25,7 @@ var keyOption = new Option<string?>(
 var keyEnvOption = new Option<string>(
     aliases: new[] { "--key-env" },
     getDefaultValue: () => "ASPNETCORE_ENCODEKEY",
-    description: "Environment variable containing AES-256 encryption key");
+    description: "Name of environment variable holding the AES-256 encryption key");
 
 // Legacy DES support — only used by decrypt commands so older ciphertext can still be read.
 // Named distinctly from reencrypt's own legacyKeyEnvOption (which has different defaults).
@@ -35,7 +35,7 @@ var decLegacyKeyOption = new Option<string?>(
 
 var decLegacyKeyEnvOption = new Option<string?>(
     aliases: new[] { "--legacy-key-env" },
-    description: "Environment variable containing legacy DES key (enables decrypting pre-v2 values)");
+    description: "Name of environment variable holding the legacy DES key (enables decrypting pre-v2 values)");
 
 // encrypt-value command — single value, AES-256-GCM
 var encryptValueCommand = new Command("encrypt-value", "Encrypt single text value");
@@ -48,8 +48,10 @@ encryptValueCommand.SetHandler((string text, string? key, string keyEnv) =>
     try
     {
         var encryptionKey = GetEncryptionKey(key, keyEnv);
-        using var aesCipher = new AesGcmCipherProvider(encryptionKey);
-        var encryptor = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+        // VersionedEncryptor.Dispose() disposes the inner AesGcmCipherProvider — we don't
+        // wrap aesCipher in a separate `using` to avoid double-dispose.
+        using var encryptor = new VersionedEncryptor(
+            new AesGcmCipherProvider(encryptionKey), legacyDes: null, allowLegacyDes: false);
         var encrypted = encryptor.Encrypt(text);
         Console.WriteLine(encrypted);
     }
@@ -76,9 +78,9 @@ decryptValueCommand.SetHandler((string encrypted, string? key, string keyEnv, st
     try
     {
         var encryptionKey = GetEncryptionKey(key, keyEnv);
-        using var aesCipher = new AesGcmCipherProvider(encryptionKey);
         var legacyDes = GetOptionalLegacyDes(legacyKey, legacyKeyEnv);
-        var encryptor = new VersionedEncryptor(aesCipher, legacyDes, allowLegacyDes: legacyDes != null);
+        using var encryptor = new VersionedEncryptor(
+            new AesGcmCipherProvider(encryptionKey), legacyDes, allowLegacyDes: legacyDes != null);
         var decrypted = encryptor.Decrypt(encrypted);
         Console.WriteLine(decrypted);
     }
@@ -127,8 +129,8 @@ encryptCommand.SetHandler(async (FileInfo input, FileInfo? output, string? key, 
         }
 
         var encryptionKey = GetEncryptionKey(key, keyEnv);
-        using var aesCipher = new AesGcmCipherProvider(encryptionKey);
-        var encryptor = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+        using var encryptor = new VersionedEncryptor(
+            new AesGcmCipherProvider(encryptionKey), legacyDes: null, allowLegacyDes: false);
 
         // Determine output file
         var outputFile = inPlace ? input : (output ?? input);
@@ -211,9 +213,9 @@ decryptCommand.SetHandler(async (System.CommandLine.Invocation.InvocationContext
         }
 
         var encryptionKey = GetEncryptionKey(key, keyEnv);
-        using var aesCipher = new AesGcmCipherProvider(encryptionKey);
         var legacyDes = GetOptionalLegacyDes(legacyKey, legacyKeyEnv);
-        var encryptor = new VersionedEncryptor(aesCipher, legacyDes, allowLegacyDes: legacyDes != null);
+        using var encryptor = new VersionedEncryptor(
+            new AesGcmCipherProvider(encryptionKey), legacyDes, allowLegacyDes: legacyDes != null);
 
         if (output.Exists && !force)
         {
@@ -272,10 +274,10 @@ var reencryptInputOption = new Option<FileInfo>(
 var legacyKeyEnvOption = new Option<string>(
     "--legacy-key-env",
     getDefaultValue: () => "ASPNETCORE_ENCODEKEY",
-    description: "Environment variable containing the legacy DES key (for reading old values)");
+    description: "Name of environment variable holding the legacy DES key (for reading old values)");
 var newKeyEnvOption = new Option<string>(
     "--new-key-env",
-    description: "Environment variable containing the new AES-256 key (for writing)") { IsRequired = true };
+    description: "Name of environment variable holding the new AES-256 key (for writing)") { IsRequired = true };
 var dryRunOption = new Option<bool>(
     "--dry-run",
     description: "Show what would be migrated without writing changes");
@@ -371,7 +373,8 @@ static string GetEncryptionKey(string? keyParam, string keyEnvVar)
 {
     if (!string.IsNullOrWhiteSpace(keyParam))
     {
-        Console.WriteLine("⚠️  Warning: Passing key via --key is not secure. Use --key-env instead.");
+        // stderr — keeps stdout clean for machine-readable commands like decrypt-value/encrypt-value.
+        Console.Error.WriteLine("⚠️  Warning: Passing key via --key is not secure. Use --key-env instead.");
         return keyParam;
     }
 
@@ -391,7 +394,8 @@ static IEncryptor? GetOptionalLegacyDes(string? legacyKey, string? legacyKeyEnv)
     string? resolved = null;
     if (!string.IsNullOrWhiteSpace(legacyKey))
     {
-        Console.WriteLine("⚠️  Warning: Passing legacy key via --legacy-key is not secure. Use --legacy-key-env instead.");
+        // stderr — keeps stdout clean for machine-readable commands like decrypt-value.
+        Console.Error.WriteLine("⚠️  Warning: Passing legacy key via --legacy-key is not secure. Use --legacy-key-env instead.");
         resolved = legacyKey;
     }
     else if (!string.IsNullOrWhiteSpace(legacyKeyEnv))

--- a/src/Voyager.Configuration.Tool/README.md
+++ b/src/Voyager.Configuration.Tool/README.md
@@ -66,6 +66,18 @@ Decrypt an encrypted JSON file to a new plain file:
 vconfig decrypt --input config/secrets.json --output config/secrets.plain.json
 ```
 
+If the file contains both modern AES-GCM (`v2:`) values and legacy DES values, supply the DES key via `--legacy-key-env`:
+
+```bash
+vconfig decrypt \
+  --input config/secrets.json \
+  --output config/secrets.plain.json \
+  --key-env ASPNETCORE_ENCODEKEY \
+  --legacy-key-env LEGACY_DES_KEY
+```
+
+Without `--legacy-key-env`, legacy DES values are left as-is (treated as plaintext). For one-shot conversion of an entire file from DES to AES, use `reencrypt` instead.
+
 ### Re-encrypt Legacy DES → AES-256-GCM
 
 Migrate a file encrypted with the legacy DES cipher to AES-256-GCM. Reads with the legacy DES key and writes with the new AES key. Use `--dry-run` first to see what would change:

--- a/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
+++ b/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
@@ -253,10 +253,10 @@ namespace Voyager.Configuration.MountPath.Test
 		[Test]
 		public void Decrypt_JsonWithComments_SkipsCommentsAndDecrypts()
 		{
-			// vconfig encrypt/decrypt currently use the legacy DES Encryptor class.
-			var key = "DesKey1234567890";
-			var encryptor = new Encryptor(key);
-			var encryptedSecret = encryptor.Encrypt("plaintext-secret");
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+			using var aesCipher = new AesGcmCipherProvider(aesKey);
+			var writer = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+			var encryptedSecret = writer.Encrypt("plaintext-secret");
 
 			// ASP.NET Core-style JSONC: line and block comments mixed in.
 			// Reproduces the bug where JsonNode.Parse threw on '/' at start of property name.
@@ -272,7 +272,7 @@ namespace Voyager.Configuration.MountPath.Test
 
 			var (exitCode, _, stderr) = RunVconfig(
 				$"decrypt --input \"{inputPath}\" --output \"{outputPath}\" --key-env TEST_KEY",
-				new Dictionary<string, string> { ["TEST_KEY"] = key });
+				new Dictionary<string, string> { ["TEST_KEY"] = aesKey });
 
 			Assert.That(exitCode, Is.EqualTo(0), () => stderr);
 
@@ -284,7 +284,7 @@ namespace Voyager.Configuration.MountPath.Test
 		[Test]
 		public void Encrypt_JsonWithTrailingComma_Succeeds()
 		{
-			var key = "DesKey1234567890";
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
 
 			var jsonWithTrailingComma = "{\n" +
 				"  \"ApiKey\": \"secret-value\",\n" +
@@ -296,15 +296,84 @@ namespace Voyager.Configuration.MountPath.Test
 
 			var (exitCode, _, stderr) = RunVconfig(
 				$"encrypt --input \"{inputPath}\" --output \"{outputPath}\" --key-env TEST_KEY",
-				new Dictionary<string, string> { ["TEST_KEY"] = key });
+				new Dictionary<string, string> { ["TEST_KEY"] = aesKey });
 
 			Assert.That(exitCode, Is.EqualTo(0), () => stderr);
 
-			// Round-trip: decrypt the encrypted output to confirm the encrypt path actually worked.
-			var encryptor = new Encryptor(key);
+			// Round-trip: decrypt the v2: encrypted output with AES to confirm the encrypt path worked.
+			using var aesCipher = new AesGcmCipherProvider(aesKey);
+			var reader = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
 			var result = JsonNode.Parse(File.ReadAllText(outputPath))!.AsObject();
-			Assert.That(encryptor.Decrypt(result["ApiKey"]!.GetValue<string>()), Is.EqualTo("secret-value"));
+			Assert.That(result["ApiKey"]!.GetValue<string>(), Does.StartWith(VersionedEncryptor.V2Prefix));
+			Assert.That(reader.Decrypt(result["ApiKey"]!.GetValue<string>()), Is.EqualTo("secret-value"));
 			Assert.That(result["Timeout"]!.GetValue<int>(), Is.EqualTo(30));
+		}
+
+		[Test]
+		public void EncryptValue_WritesV2Prefix()
+		{
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+			var (exitCode, stdout, stderr) = RunVconfig(
+				$"encrypt-value \"my-secret\" --key-env TEST_KEY",
+				new Dictionary<string, string> { ["TEST_KEY"] = aesKey });
+
+			Assert.That(exitCode, Is.EqualTo(0), () => stderr);
+			Assert.That(stdout, Does.StartWith(VersionedEncryptor.V2Prefix));
+
+			// Round-trip via library
+			using var aesCipher = new AesGcmCipherProvider(aesKey);
+			var reader = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+			Assert.That(reader.Decrypt(stdout), Is.EqualTo("my-secret"));
+		}
+
+		[Test]
+		public void DecryptValue_WithLegacyKeyEnv_ReadsDesCiphertext()
+		{
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+			var desKey = "LegacyDesKey12345678";
+			var desCiphertext = new Encryptor(desKey).Encrypt("legacy-secret");
+
+			var (exitCode, stdout, stderr) = RunVconfig(
+				$"decrypt-value \"{desCiphertext}\" --key-env TEST_AES --legacy-key-env TEST_DES",
+				new Dictionary<string, string> { ["TEST_AES"] = aesKey, ["TEST_DES"] = desKey });
+
+			Assert.That(exitCode, Is.EqualTo(0), () => stderr);
+			Assert.That(stdout, Is.EqualTo("legacy-secret"));
+		}
+
+		[Test]
+		public void Decrypt_JsonWithMixedV2AndDes_WithLegacyKey_DecryptsBoth()
+		{
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+			var desKey = "LegacyDesKey12345678";
+
+			using var aesCipher = new AesGcmCipherProvider(aesKey);
+			var aesWriter = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+			var desEncryptor = new Encryptor(desKey);
+
+			var json = new JsonObject
+			{
+				["modernSecret"] = aesWriter.Encrypt("modern-value"),
+				["legacySecret"] = desEncryptor.Encrypt("legacy-value"),
+				["plainText"] = "not encrypted",
+				["count"] = 42
+			};
+			var inputPath = Path.Combine(_tempDir, "mixed.json");
+			var outputPath = Path.Combine(_tempDir, "mixed.plain.json");
+			File.WriteAllText(inputPath, json.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+			var (exitCode, _, stderr) = RunVconfig(
+				$"decrypt --input \"{inputPath}\" --output \"{outputPath}\" --key-env TEST_AES --legacy-key-env TEST_DES",
+				new Dictionary<string, string> { ["TEST_AES"] = aesKey, ["TEST_DES"] = desKey });
+
+			Assert.That(exitCode, Is.EqualTo(0), () => stderr);
+
+			var result = JsonNode.Parse(File.ReadAllText(outputPath))!.AsObject();
+			Assert.That(result["modernSecret"]!.GetValue<string>(), Is.EqualTo("modern-value"));
+			Assert.That(result["legacySecret"]!.GetValue<string>(), Is.EqualTo("legacy-value"));
+			Assert.That(result["plainText"]!.GetValue<string>(), Is.EqualTo("not encrypted"));
+			Assert.That(result["count"]!.GetValue<int>(), Is.EqualTo(42));
 		}
 
 		[Test]

--- a/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
+++ b/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
@@ -255,7 +255,7 @@ namespace Voyager.Configuration.MountPath.Test
 		{
 			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
 			using var aesCipher = new AesGcmCipherProvider(aesKey);
-			var writer = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+			using var writer = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
 			var encryptedSecret = writer.Encrypt("plaintext-secret");
 
 			// ASP.NET Core-style JSONC: line and block comments mixed in.
@@ -302,7 +302,7 @@ namespace Voyager.Configuration.MountPath.Test
 
 			// Round-trip: decrypt the v2: encrypted output with AES to confirm the encrypt path worked.
 			using var aesCipher = new AesGcmCipherProvider(aesKey);
-			var reader = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+			using var reader = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
 			var result = JsonNode.Parse(File.ReadAllText(outputPath))!.AsObject();
 			Assert.That(result["ApiKey"]!.GetValue<string>(), Does.StartWith(VersionedEncryptor.V2Prefix));
 			Assert.That(reader.Decrypt(result["ApiKey"]!.GetValue<string>()), Is.EqualTo("secret-value"));
@@ -323,7 +323,7 @@ namespace Voyager.Configuration.MountPath.Test
 
 			// Round-trip via library
 			using var aesCipher = new AesGcmCipherProvider(aesKey);
-			var reader = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+			using var reader = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
 			Assert.That(reader.Decrypt(stdout), Is.EqualTo("my-secret"));
 		}
 
@@ -349,7 +349,7 @@ namespace Voyager.Configuration.MountPath.Test
 			var desKey = "LegacyDesKey12345678";
 
 			using var aesCipher = new AesGcmCipherProvider(aesKey);
-			var aesWriter = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
+			using var aesWriter = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
 			var desEncryptor = new Encryptor(desKey);
 
 			var json = new JsonObject


### PR DESCRIPTION
## Summary

Closes ADR-010 Phase 1 step 5 — \"Update Encryptor.Encrypt call sites to emit \`v2:\` format.\"

The library has been on AES-256-GCM via \`VersionedEncryptor\` since v2.3.0, but the CLI's \`encrypt\`, \`decrypt\`, \`encrypt-value\`, and \`decrypt-value\` commands kept instantiating the legacy DES \`Encryptor\` directly. Net effect: \`vconfig encrypt\` produced unprefixed DES Base64, and \`vconfig decrypt\` could not read \`v2:\` AES ciphertext at all — only \`reencrypt\` touched AES. This PR aligns the CLI with the library default.

## Changes

- All four commands now build a \`VersionedEncryptor\` over an \`AesGcmCipherProvider\`. Encrypt paths emit \`v2:\` ciphertext.
- \`decrypt\` and \`decrypt-value\` gain \`--legacy-key\` / \`--legacy-key-env\` so files mixing AES and legacy DES values can be read end-to-end. Without the legacy key, DES values fall through the lenient catch and are left as-is (existing tolerant behavior).
- Existing JSONC regression tests switched from DES to AES keys; three new tests cover \`v2:\` emission, legacy DES decryption via \`--legacy-key-env\`, and a mixed v2/DES file decrypt round-trip. All 14 \`VconfigCliTest\` tests pass.
- README documents the \`--legacy-key-env\` decrypt option.

## Breaking change

\`vconfig encrypt -k \"DesKey...\"\` no longer produces DES output. AES keys must be Base64-encoded 32 bytes (\`vconfig keygen\`). Existing DES-encrypted files migrate via \`vconfig reencrypt\`.

This was always the direction in ADR-010 — the CLI just hadn't caught up yet. Library consumers using \`IEncryptorFactory\` are unaffected (they were already on AES).

## Related

- Closes ADR-010 Phase 1 step 5.
- ADR-010 housekeeping (Phase 5 steps 17–18) lives in #12.

## Test plan

- [ ] Build passes (\`dotnet build src/Voyager.Configuration.Tool\`).
- [ ] Full \`VconfigCliTest\` suite green (14 tests).
- [ ] Smoke: \`vconfig keygen | tee key.txt; ASPNETCORE_ENCODEKEY=\$(cat key.txt) vconfig encrypt -i sample.json -o sample.enc.json\` → output values start with \`v2:\`.
- [ ] Smoke: round-trip with the user's original failing command (\`vconfig decrypt -i ... -k <Base64-32B>\`) on a JSONC file works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)