### PR TITLE
fix(vconfig): decrypt fails loud when a value can't be decrypted

### DIFF
--- a/src/Voyager.Configuration.Tool/Program.cs
+++ b/src/Voyager.Configuration.Tool/Program.cs
@@ -472,7 +472,7 @@ static JsonNode DecryptJsonNode(JsonNode node, IEncryptor encryptor, string path
         var result = new JsonObject();
         foreach (var (key, val) in obj)
         {
-            result[key] = val != null ? DecryptJsonNode(val, encryptor, $"{path}.{key}") : null;
+            result[key] = val != null ? DecryptJsonNode(val, encryptor, AppendJsonPathKey(path, key)) : null;
         }
         return result;
     }
@@ -487,6 +487,33 @@ static JsonNode DecryptJsonNode(JsonNode node, IEncryptor encryptor, string path
         return result;
     }
     return node.DeepClone();
+}
+
+// JSONPath child accessor. Uses dot-notation for simple identifiers (`$.foo`) and
+// bracket-notation for keys with dots/special chars (`$['Microsoft.Hosting.Lifetime']`).
+// Without this, a config key like "Microsoft.Hosting.Lifetime" would render as
+// `$.Microsoft.Hosting.Lifetime` and look like three nested levels.
+static string AppendJsonPathKey(string path, string key)
+{
+    bool isSimpleIdentifier = key.Length > 0;
+    if (isSimpleIdentifier)
+    {
+        foreach (var c in key)
+        {
+            if (!char.IsLetterOrDigit(c) && c != '_')
+            {
+                isSimpleIdentifier = false;
+                break;
+            }
+        }
+    }
+
+    if (isSimpleIdentifier)
+        return $"{path}.{key}";
+
+    // Bracket notation — escape backslashes first, then single quotes.
+    var escaped = key.Replace("\\", "\\\\").Replace("'", "\\'");
+    return $"{path}['{escaped}']";
 }
 
 static JsonNode ReencryptJsonNode(

--- a/src/Voyager.Configuration.Tool/Program.cs
+++ b/src/Voyager.Configuration.Tool/Program.cs
@@ -236,8 +236,8 @@ decryptCommand.SetHandler(async (System.CommandLine.Invocation.InvocationContext
             Environment.Exit(1);
         }
 
-        // Decrypt values
-        var decryptedNode = DecryptJsonNode(jsonNode, encryptor);
+        // Decrypt values — strict: any decrypt failure is reported with JSON path and exits non-zero.
+        var decryptedNode = DecryptJsonNode(jsonNode, encryptor, "$");
 
         // Write output
         var options = new JsonSerializerOptions { WriteIndented = true };
@@ -443,25 +443,28 @@ static JsonNode EncryptJsonNode(JsonNode node, IEncryptor encryptor)
     return node.DeepClone();
 }
 
-static JsonNode DecryptJsonNode(JsonNode node, IEncryptor encryptor)
+// Strict decrypt: every string value must decrypt cleanly. A failure is wrapped with the
+// JSON path so the user can see which value failed (and `vconfig encrypt` is symmetric, so
+// every string in a vconfig-encrypted file is expected to be ciphertext).
+static JsonNode DecryptJsonNode(JsonNode node, IEncryptor encryptor, string path)
 {
     if (node is JsonValue value)
     {
-        // Decrypt only string values
         if (value.TryGetValue<string>(out var str))
         {
             try
             {
-                // Try to decrypt - if it fails, it might not be encrypted
                 return JsonValue.Create(encryptor.Decrypt(str));
             }
-            catch
+            catch (Exception ex)
             {
-                // Not encrypted, return as-is
-                return value.DeepClone();
+                throw new InvalidOperationException(
+                    $"Failed to decrypt value at '{path}'. " +
+                    "Verify the key matches the one used to encrypt and that the value was produced by 'vconfig encrypt'. " +
+                    $"Underlying error: {ex.Message}", ex);
             }
         }
-        // Numbers, booleans remain unchanged
+        // Numbers, booleans, null remain unchanged
         return value.DeepClone();
     }
     else if (node is JsonObject obj)
@@ -469,16 +472,17 @@ static JsonNode DecryptJsonNode(JsonNode node, IEncryptor encryptor)
         var result = new JsonObject();
         foreach (var (key, val) in obj)
         {
-            result[key] = val != null ? DecryptJsonNode(val, encryptor) : null;
+            result[key] = val != null ? DecryptJsonNode(val, encryptor, $"{path}.{key}") : null;
         }
         return result;
     }
     else if (node is JsonArray arr)
     {
         var result = new JsonArray();
-        foreach (var item in arr)
+        for (int i = 0; i < arr.Count; i++)
         {
-            result.Add(item != null ? DecryptJsonNode(item, encryptor) : null);
+            var item = arr[i];
+            result.Add(item != null ? DecryptJsonNode(item, encryptor, $"{path}[{i}]") : null);
         }
         return result;
     }

--- a/src/Voyager.Configuration.Tool/Program.cs
+++ b/src/Voyager.Configuration.Tool/Program.cs
@@ -456,7 +456,13 @@ static JsonNode DecryptJsonNode(JsonNode node, IEncryptor encryptor, string path
             {
                 return JsonValue.Create(encryptor.Decrypt(str));
             }
-            catch (Exception ex)
+            // Only the exception types Decrypt is documented/expected to raise for bad
+            // ciphertext or wrong key. Anything else (OOM, OperationCanceledException,
+            // genuine bugs) must propagate unwrapped so diagnostics aren't misleading.
+            catch (Exception ex) when (
+                ex is EncryptionException ||
+                ex is CryptographicException ||
+                ex is FormatException)
             {
                 throw new InvalidOperationException(
                     $"Failed to decrypt value at '{path}'. " +
@@ -490,16 +496,18 @@ static JsonNode DecryptJsonNode(JsonNode node, IEncryptor encryptor, string path
 }
 
 // JSONPath child accessor. Uses dot-notation for simple identifiers (`$.foo`) and
-// bracket-notation for keys with dots/special chars (`$['Microsoft.Hosting.Lifetime']`).
-// Without this, a config key like "Microsoft.Hosting.Lifetime" would render as
-// `$.Microsoft.Hosting.Lifetime` and look like three nested levels.
+// bracket-notation for everything else (`$['Microsoft.Hosting.Lifetime']`, `$['123']`).
+// "Simple identifier" matches the JSONPath dot-notation rule: first char is a letter or
+// underscore, remaining chars are letters/digits/underscore. Keys starting with a digit
+// (e.g. "123") would render as `$.123` — invalid in many JSONPath parsers.
 static string AppendJsonPathKey(string path, string key)
 {
-    bool isSimpleIdentifier = key.Length > 0;
+    bool isSimpleIdentifier = key.Length > 0 && (char.IsLetter(key[0]) || key[0] == '_');
     if (isSimpleIdentifier)
     {
-        foreach (var c in key)
+        for (int i = 1; i < key.Length; i++)
         {
+            var c = key[i];
             if (!char.IsLetterOrDigit(c) && c != '_')
             {
                 isSimpleIdentifier = false;

--- a/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
+++ b/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
@@ -352,11 +352,11 @@ namespace Voyager.Configuration.MountPath.Test
 			using var aesWriter = new VersionedEncryptor(aesCipher, legacyDes: null, allowLegacyDes: false);
 			var desEncryptor = new Encryptor(desKey);
 
+			// Strict-decrypt: every string must be ciphertext. Numbers are left alone.
 			var json = new JsonObject
 			{
 				["modernSecret"] = aesWriter.Encrypt("modern-value"),
 				["legacySecret"] = desEncryptor.Encrypt("legacy-value"),
-				["plainText"] = "not encrypted",
 				["count"] = 42
 			};
 			var inputPath = Path.Combine(_tempDir, "mixed.json");
@@ -372,8 +372,86 @@ namespace Voyager.Configuration.MountPath.Test
 			var result = JsonNode.Parse(File.ReadAllText(outputPath))!.AsObject();
 			Assert.That(result["modernSecret"]!.GetValue<string>(), Is.EqualTo("modern-value"));
 			Assert.That(result["legacySecret"]!.GetValue<string>(), Is.EqualTo("legacy-value"));
-			Assert.That(result["plainText"]!.GetValue<string>(), Is.EqualTo("not encrypted"));
 			Assert.That(result["count"]!.GetValue<int>(), Is.EqualTo(42));
+		}
+
+		[Test]
+		public void Encrypt_Then_Decrypt_RoundTrip_RestoresOriginalValues()
+		{
+			// Full CLI round-trip: vconfig encrypt → vconfig decrypt with the same key.
+			// This is the most basic invariant — if it doesn't hold, the tool is broken.
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+			var originalJson =
+				"{\n" +
+				"  \"ConnectionString\": \"Server=db;Password=secret\",\n" +
+				"  \"ApiKey\": \"my-api-key with spaces and stuff\",\n" +
+				"  \"Nested\": { \"InnerSecret\": \"deep-value\" },\n" +
+				"  \"Timeout\": 30,\n" +
+				"  \"Enabled\": true\n" +
+				"}\n";
+			var inputPath = Path.Combine(_tempDir, "config.json");
+			var encryptedPath = Path.Combine(_tempDir, "config.encrypted.json");
+			var decryptedPath = Path.Combine(_tempDir, "config.decrypted.json");
+			File.WriteAllText(inputPath, originalJson);
+
+			var (encExit, _, encErr) = RunVconfig(
+				$"encrypt --input \"{inputPath}\" --output \"{encryptedPath}\" --key-env TEST_KEY",
+				new Dictionary<string, string> { ["TEST_KEY"] = aesKey });
+			Assert.That(encExit, Is.EqualTo(0), () => encErr);
+
+			// String values are now ciphertext (v2: prefix); non-strings unchanged.
+			var encrypted = JsonNode.Parse(File.ReadAllText(encryptedPath))!.AsObject();
+			Assert.That(encrypted["ConnectionString"]!.GetValue<string>(),
+				Does.StartWith(VersionedEncryptor.V2Prefix));
+			Assert.That(encrypted["ApiKey"]!.GetValue<string>(),
+				Does.StartWith(VersionedEncryptor.V2Prefix));
+			Assert.That(encrypted["Nested"]!["InnerSecret"]!.GetValue<string>(),
+				Does.StartWith(VersionedEncryptor.V2Prefix));
+			Assert.That(encrypted["Timeout"]!.GetValue<int>(), Is.EqualTo(30));
+			Assert.That(encrypted["Enabled"]!.GetValue<bool>(), Is.True);
+
+			var (decExit, _, decErr) = RunVconfig(
+				$"decrypt --input \"{encryptedPath}\" --output \"{decryptedPath}\" --key-env TEST_KEY",
+				new Dictionary<string, string> { ["TEST_KEY"] = aesKey });
+			Assert.That(decExit, Is.EqualTo(0), () => decErr);
+
+			var decrypted = JsonNode.Parse(File.ReadAllText(decryptedPath))!.AsObject();
+			Assert.That(decrypted["ConnectionString"]!.GetValue<string>(),
+				Is.EqualTo("Server=db;Password=secret"));
+			Assert.That(decrypted["ApiKey"]!.GetValue<string>(),
+				Is.EqualTo("my-api-key with spaces and stuff"));
+			Assert.That(decrypted["Nested"]!["InnerSecret"]!.GetValue<string>(),
+				Is.EqualTo("deep-value"));
+			Assert.That(decrypted["Timeout"]!.GetValue<int>(), Is.EqualTo(30));
+			Assert.That(decrypted["Enabled"]!.GetValue<bool>(), Is.True);
+		}
+
+		[Test]
+		public void Decrypt_NonEncryptedValue_FailsLoudWithJsonPath()
+		{
+			// Strict mode: a string that isn't valid ciphertext must error out (no silent passthrough).
+			// The error must include the JSON path so the user knows which value broke.
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+			var plaintextJson =
+				"{\n" +
+				"  \"Database\": {\n" +
+				"    \"ConnectionString\": \"Server=localhost\"\n" +
+				"  }\n" +
+				"}\n";
+			var inputPath = Path.Combine(_tempDir, "plain.json");
+			var outputPath = Path.Combine(_tempDir, "out.json");
+			File.WriteAllText(inputPath, plaintextJson);
+
+			var (exitCode, _, stderr) = RunVconfig(
+				$"decrypt --input \"{inputPath}\" --output \"{outputPath}\" --key-env TEST_KEY",
+				new Dictionary<string, string> { ["TEST_KEY"] = aesKey });
+
+			Assert.That(exitCode, Is.Not.EqualTo(0),
+				"decrypt of a plaintext value must fail (no silent fallthrough)");
+			Assert.That(stderr, Does.Contain("ConnectionString"),
+				"error message must reference the failing JSON path");
 		}
 
 		[Test]

--- a/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
+++ b/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
@@ -455,6 +455,31 @@ namespace Voyager.Configuration.MountPath.Test
 		}
 
 		[Test]
+		public void Decrypt_KeyStartingWithDigit_ReportedInBracketNotation()
+		{
+			// "123" is not a valid JSONPath dot-notation identifier (must start with letter/_),
+			// so it must use bracket notation `$['123']` rather than `$.123`.
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+			var json = "{\n" +
+				"  \"Items\": {\n" +
+				"    \"123\": \"plaintext-not-ciphertext\"\n" +
+				"  }\n" +
+				"}\n";
+			var inputPath = Path.Combine(_tempDir, "config.json");
+			var outputPath = Path.Combine(_tempDir, "out.json");
+			File.WriteAllText(inputPath, json);
+
+			var (exitCode, _, stderr) = RunVconfig(
+				$"decrypt --input \"{inputPath}\" --output \"{outputPath}\" --key-env TEST_KEY",
+				new Dictionary<string, string> { ["TEST_KEY"] = aesKey });
+
+			Assert.That(exitCode, Is.Not.EqualTo(0));
+			Assert.That(stderr, Does.Contain("$.Items['123']"),
+				"key starting with a digit must use bracket notation");
+		}
+
+		[Test]
 		public void Decrypt_KeyWithDots_ReportedInBracketNotation()
 		{
 			// ASP.NET Core configs commonly use keys like "Microsoft.Hosting.Lifetime".

--- a/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
+++ b/test/Voyager.Configuration.MountPath.Test/VconfigCliTest.cs
@@ -450,8 +450,36 @@ namespace Voyager.Configuration.MountPath.Test
 
 			Assert.That(exitCode, Is.Not.EqualTo(0),
 				"decrypt of a plaintext value must fail (no silent fallthrough)");
-			Assert.That(stderr, Does.Contain("ConnectionString"),
-				"error message must reference the failing JSON path");
+			Assert.That(stderr, Does.Contain("$.Database.ConnectionString"),
+				"error must report the full JSON path, not just the leaf key");
+		}
+
+		[Test]
+		public void Decrypt_KeyWithDots_ReportedInBracketNotation()
+		{
+			// ASP.NET Core configs commonly use keys like "Microsoft.Hosting.Lifetime".
+			// Dot-notation would render that as `$.Microsoft.Hosting.Lifetime` — looks like
+			// three levels of nesting. Bracket notation disambiguates.
+			var aesKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+			var json = "{\n" +
+				"  \"Logging\": {\n" +
+				"    \"LogLevel\": {\n" +
+				"      \"Microsoft.Hosting.Lifetime\": \"plaintext-not-ciphertext\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}\n";
+			var inputPath = Path.Combine(_tempDir, "config.json");
+			var outputPath = Path.Combine(_tempDir, "out.json");
+			File.WriteAllText(inputPath, json);
+
+			var (exitCode, _, stderr) = RunVconfig(
+				$"decrypt --input \"{inputPath}\" --output \"{outputPath}\" --key-env TEST_KEY",
+				new Dictionary<string, string> { ["TEST_KEY"] = aesKey });
+
+			Assert.That(exitCode, Is.Not.EqualTo(0));
+			Assert.That(stderr, Does.Contain("$.Logging.LogLevel['Microsoft.Hosting.Lifetime']"),
+				"key with dots must be rendered in bracket notation");
 		}
 
 		[Test]


### PR DESCRIPTION
## Summary

\`vconfig decrypt\` was silently keeping ciphertext values when decryption threw — the wrapping \`try { ... } catch { return value.DeepClone(); }\` in \`DecryptJsonNode\` swallowed every error and the command still printed \`✓ Decrypted successfully\`. Users hit this exact failure mode after upgrading from the DES-era CLI to AES: their pre-\`v2:\` ciphertext had no legacy key configured, every decrypt threw \`EncryptionException\`, and the output file was byte-identical to the input.

The library side already fails fast (\`EncryptedJsonConfigurationProvider\` re-throws as \`EncryptionException\` with file + key context, so the app refuses to start). The CLI now matches that contract.

## Changes

- \`DecryptJsonNode\` recurses with a JSONPath-style breadcrumb (\`$\`, \`$.foo\`, \`$.list[3].bar\`). Decrypt failure is wrapped in \`InvalidOperationException\` carrying that path plus the underlying message and a one-liner pointing the user at the likely cause (wrong key / not produced by \`vconfig encrypt\`).
- The outer command handler's \`catch (Exception ex)\` already prints \`Error: …\` to stderr and exits 1, so no plumbing change there.
- New test \`Encrypt_Then_Decrypt_RoundTrip_RestoresOriginalValues\`: full CLI-to-CLI round-trip on a nested JSON. The most basic invariant — if it ever breaks again we want to find out instantly.
- New test \`Decrypt_NonEncryptedValue_FailsLoudWithJsonPath\`: feed a plaintext file to decrypt, assert non-zero exit and that stderr names the failing key. Regression test for this exact silent-swallow bug.
- Updated \`Decrypt_JsonWithMixedV2AndDes_WithLegacyKey_DecryptsBoth\`: dropped the \`\"plainText\": \"not encrypted\"\` field — it was relying on the lenient-catch behavior this PR removes. Numbers/bools are still passed through unchanged (strict mode only touches strings).

## User-visible behavior change

Before: \`vconfig decrypt\` of a file with even one non-decryptable value succeeded silently and produced an output file with that value unchanged. Multiplied across a config file, the output could equal the input.

After: \`vconfig decrypt\` exits 1 with a stderr message like:
\`\`\`
Error: Failed to decrypt value at '\$.Database.ConnectionString'. Verify the key matches the one used to encrypt and that the value was produced by 'vconfig encrypt'. Underlying error: ...
\`\`\`

For pure-ciphertext files (the normal output of \`vconfig encrypt\`), nothing changes — they round-trip cleanly.

## Test plan

- [ ] All 16 \`VconfigCliTest\` tests pass.
- [ ] Manual: \`vconfig encrypt\` a file → \`vconfig decrypt\` with same key → diff against original (must be identical).
- [ ] Manual: \`vconfig decrypt\` a plaintext file → must exit 1 and name the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)